### PR TITLE
DataProvider

### DIFF
--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -1,6 +1,13 @@
 import allure
 
+from data import urls
 from pages.base_page import BasePage
+from faker import Faker
+from data.locators.login_page_locators import LoginPageLocators as lloc
+from data.locators.home_page_locators import HomePageLocators as hloc
+
+url = urls.Urls
+fake = Faker()
 
 
 class LoginPage(BasePage):
@@ -16,6 +23,51 @@ class LoginPage(BasePage):
         'password_label': 'Password',
         'login_button': 'Login'
     }
+
+    TEST_CASES = [
+        {
+            "name": "valid_credentials",
+            "credentials": {
+                "username": "angular",
+                "password": "password",
+                "username_desc": f"{fake.word()}"
+            },
+            "expected": {
+                "success": True,
+                "url": url.HOME_PAGE,
+                "element": hloc.SUCCESS_MESSAGE,
+                "text_key": "success_text"
+            }
+        },
+        {
+            "name": "invalid_username",
+            "credentials": {
+                "username": f"{fake.name()}",
+                "password": "password",
+                "username_desc": f"{fake.word()}",
+            },
+            "expected": {
+                "success": False,
+                "url": url.LOGIN_PAGE,
+                "element": lloc.ALERT_LOGIN_ERROR,
+                "text_key": "alert_text"
+            }
+        },
+        {
+            "name": "invalid_password",
+            "credentials": {
+                "username": "angular",
+                "password": f"{fake.password()}",
+                "username_desc": f"{fake.word()}"
+            },
+            "expected": {
+                "success": False,
+                "url": url.LOGIN_PAGE,
+                "element": lloc.ALERT_LOGIN_ERROR,
+                "text_key": "alert_text"
+            }
+        }
+    ]
 
     def get_field_label(self, locator: tuple) -> str:
         with allure.step(f'Получение текста описания поля'):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
-addopts = -v -s
-;--alluredir=./allure-results --clean-alluredir
+addopts = -v -s --alluredir=./allure-results --clean-alluredir
 
 
 ;--alluredir=./allure-results --clean-alluredir

--- a/tests/TS04_parametrized_authorization/test_v1_login_parametrized.py
+++ b/tests/TS04_parametrized_authorization/test_v1_login_parametrized.py
@@ -1,0 +1,62 @@
+import allure
+import pytest
+from faker import Faker
+
+from data.locators.login_page_locators import LoginPageLocators as lloc
+from data.locators.home_page_locators import HomePageLocators as hloc
+from data.urls import Urls
+
+urls = Urls()
+fake = Faker()
+
+
+@allure.epic('Авторизация')
+@allure.feature('Страница авторизации')
+@allure.story('Авторизация all type data')
+@allure.severity(allure.severity_level.CRITICAL)
+@pytest.mark.parametrize(
+    'name, username, password, username_desc',
+    [
+        ('Валидные данные', 'angular', 'password', f'{fake.word()}'),
+        ('Невалидный username', f'{fake.name()}', 'password', f'{fake.word()}'),
+        ('Невалидный password', 'angular', f'{fake.password()}', f'{fake.word()}')
+    ],
+    ids=['valid_data', 'invalid_username', 'invalid_password']
+)
+def test_login_authorization(open_auth_page, pages, name, username, password, username_desc):
+    auth_page = open_auth_page
+    home_page = pages.home
+    exp_text = auth_page.EXPECTED_TEXTS
+
+    with allure.step(f'Тестовый случай: {name}'):
+        with allure.step('1. Заполнить поля формы'):
+            auth_page.fill_field(lloc.USERNAME_FIELD, username)
+            auth_page.fill_field(lloc.PASSWORD_FIELD, password)
+            auth_page.fill_field(lloc.USERNAME_DESC_FIELD, username_desc)
+
+        with allure.step('2. Нажать  кнопку "Login"'):
+            auth_page.click_element(lloc.LOGIN_BUTTON)
+
+        if name == 'Валидные данные':
+            home_page.await_for_js_reaction()
+            with allure.step('3. Проверка URL страницы'):
+                assert home_page.get_current_url() == urls.HOME_PAGE, \
+                    'URL страницы не соответствует ожидаемому'
+            with allure.step('4. Проверка заголовка страницы'):
+                assert home_page.get_title() == exp_text['page_title'], \
+                    'Заголовок страницы не соответствует ожидаемому'
+            with allure.step('5. Проверка текста сообщения'):
+                assert home_page.get_text_by_locator(hloc.SUCCESS_MESSAGE) == \
+                        exp_text['success_text'], \
+                        'Текст сообщения не соответствует ожидаемому'
+        else:
+            with allure.step('3. Проверка URL страницы'):
+                assert auth_page.get_current_url() != urls.HOME_PAGE, \
+                    'URL страницы изменился'
+            with allure.step('4. Проверка наличия сообщения'):
+                assert auth_page.is_element_visible(lloc.ALERT_LOGIN_ERROR), \
+                    'Не отображается сообщение об ошибке'
+            with allure.step('5. Проверка текста сообщения об ошибке'):
+                alert_text = auth_page.get_text(auth_page.find_element(lloc.ALERT_LOGIN_ERROR))
+                assert alert_text == exp_text['alert_text'], \
+                    f'Текст ошибки не соответствует ожидаемому.'

--- a/tests/TS04_parametrized_authorization/test_v2_login_parametrized.py
+++ b/tests/TS04_parametrized_authorization/test_v2_login_parametrized.py
@@ -1,0 +1,58 @@
+import allure
+import pytest
+
+from data.locators.login_page_locators import LoginPageLocators as lloc
+from data.urls import Urls
+from pages.login_page import LoginPage as lp
+
+urls = Urls()
+
+TEST_CASES = lp.TEST_CASES
+
+
+@allure.epic('Авторизация')
+@allure.feature('Страница авторизации')
+@allure.story('Авторизация all type data')
+@allure.severity(allure.severity_level.CRITICAL)
+@pytest.mark.parametrize('test_case',
+                         TEST_CASES,
+                         ids=[case['name'] for case in TEST_CASES])
+def test_login_authorization(open_auth_page, pages, test_case):
+    auth_page = open_auth_page
+    home_page = pages.home
+    exp_text = auth_page.EXPECTED_TEXTS
+
+    with allure.step(f'Тестовый случай: {test_case['name']}'):
+        with allure.step('1. Заполнить поля формы'):
+            auth_page.fill_field(lloc.USERNAME_FIELD, test_case['credentials']['username'])
+            auth_page.fill_field(lloc.PASSWORD_FIELD, test_case['credentials']['password'])
+            auth_page.fill_field(lloc.USERNAME_DESC_FIELD, test_case['credentials']['username_desc'])
+
+        with allure.step('2. Нажать  кнопку "Login"'):
+            auth_page.click_element(lloc.LOGIN_BUTTON)
+
+        if test_case['expected']['success']:
+            home_page.await_for_js_reaction()
+            with allure.step('3. Проверка URL страницы'):
+                assert home_page.get_current_url() == test_case['expected']['url'], \
+                    f'URL страницы не соответствует ожидаемому: {test_case['expected']['url']}'
+
+            with allure.step('4. Проверка заголовка страницы'):
+                assert home_page.get_title() == exp_text['page_title'], \
+                    'Заголовок страницы не соответствует ожидаемому'
+
+            with allure.step('5. Проверка текста сообщения'):
+                assert home_page.get_text_by_locator(test_case['expected']['element']) == \
+                        exp_text[test_case['expected']['text_key']], \
+                        'Текст сообщения не соответствует ожидаемому'
+        else:
+            with allure.step('3. Проверка URL страницы'):
+                assert auth_page.get_current_url() != urls.HOME_PAGE, \
+                    'URL страницы изменился'
+                with allure.step('4. Проверка наличия сообщения'):
+                    assert auth_page.is_element_visible(test_case['expected']['element']), \
+                        'Не отображается сообщение об ошибке'
+                with allure.step('5. Проверка текста сообщения об ошибке'):
+                    alert_text = auth_page.get_text(auth_page.find_element(test_case['expected']['element']))
+                    assert alert_text == exp_text[test_case['expected']['text_key']], \
+                        f'Текст ошибки не соответствует ожидаемому: {exp_text[test_case['expected']['text_key']]}'


### PR DESCRIPTION
Добавлены два параметризованных теста на авторизацию пользователя.
Проверки:
- валидные данные;
- не валидный пароль;
- не валидный логин.
 
Реализовано два варианта организации тестовых данных: 
- в тесте - test_v1_login_parametrized.py _(нагляднее, но тест массивнее)_;
- в  модуле страницы - test_v2_login_parametrized.py _(компактнее, но понимание усложняется)_.
Не знал, какой выбрать - оставил оба. 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
![image](https://github.com/user-attachments/assets/1896134f-43b6-4124-a7db-eef9e77964af)

